### PR TITLE
Add Python linting tools and CI workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,20 @@
+name: Python CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install '.[dev]'
+      - run: black --check .
+      - run: isort --check-only .
+      - run: flake8
+      - run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "cdr"
+version = "0.1.0"
+description = "Python package for the cdr project"
+requires-python = ">=3.10"
+dependencies = [
+  "typing",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "black",
+  "isort",
+  "flake8",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- require Python 3.10+ and document Python tooling
- add black, isort, and flake8 as development dependencies
- run Python linting and tests in a new GitHub Actions workflow

## Testing
- `pip install '.[dev]'`
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest`
- `npm test`
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68911f7a0d588330939fe5702c6cf760