### PR TITLE
Add initial Python module structure and utilities

### DIFF
--- a/cdr/__init__.py
+++ b/cdr/__init__.py
@@ -1,0 +1,42 @@
+"""Python port of the ``cdr`` TypeScript library.
+
+At this stage the port only includes a subset of the original project –
+primarily enumerations and small utility helpers.  The public API mirrors
+``src/index.ts`` of the original repository by re-exporting the
+implemented components.
+"""
+
+from __future__ import annotations
+
+from .encapsulation_kind import EncapsulationKind
+from .get_encapsulation_kind_info import (
+    EncapsulationInfo,
+    get_encapsulation_kind_info,
+)
+from .is_big_endian import is_big_endian
+from .length_codes import (
+    LengthCode,
+    LengthCodeError,
+    get_length_code_for_object_size,
+    length_code_to_object_sizes,
+)
+from .reader import CdrReader
+from .reserved_pids import EXTENDED_PID, SENTINEL_PID
+from .size_calculator import CdrSizeCalculator
+from .writer import CdrWriter
+
+__all__ = [
+    "EncapsulationKind",
+    "EncapsulationInfo",
+    "get_encapsulation_kind_info",
+    "is_big_endian",
+    "LengthCode",
+    "LengthCodeError",
+    "get_length_code_for_object_size",
+    "length_code_to_object_sizes",
+    "CdrReader",
+    "CdrWriter",
+    "CdrSizeCalculator",
+    "EXTENDED_PID",
+    "SENTINEL_PID",
+]

--- a/cdr/encapsulation_kind.py
+++ b/cdr/encapsulation_kind.py
@@ -1,0 +1,45 @@
+"""Enumerations for CDR encapsulation kinds.
+
+This mirrors the constants defined in the TypeScript library's
+``EncapsulationKind`` enum.  The values originate from the
+DDS-XTypes specification and are used to describe how data is
+serialized within a CDR stream.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class EncapsulationKind(IntEnum):
+    """Enumeration of the various CDR encapsulation kinds.
+
+    The integer values match those used by the TypeScript implementation
+    and the DDS-XTypes specification.  They are intentionally defined as
+    ``IntEnum`` so that the values can be used directly in binary
+    operations or compared against integers.
+    """
+
+    # Plain CDR encodings
+    CDR_BE = 0x00  # Plain CDR, big-endian
+    CDR_LE = 0x01  # Plain CDR, little-endian
+
+    # Parameter list CDR encodings (XCDR1)
+    PL_CDR_BE = 0x02  # Parameter List CDR, big-endian
+    PL_CDR_LE = 0x03  # Parameter List CDR, little-endian
+
+    # XCDR2 encodings
+    CDR2_BE = 0x10  # Plain CDR2, big-endian
+    CDR2_LE = 0x11  # Plain CDR2, little-endian
+    PL_CDR2_BE = 0x12  # Parameter List CDR2, big-endian
+    PL_CDR2_LE = 0x13  # Parameter List CDR2, little-endian
+    DELIMITED_CDR2_BE = 0x14  # Delimited CDR2, big-endian
+    DELIMITED_CDR2_LE = 0x15  # Delimited CDR2, little-endian
+
+    # RTPS specific IDs for XCDR2
+    RTPS_CDR2_BE = 0x06  # Plain CDR2, big-endian
+    RTPS_CDR2_LE = 0x07  # Plain CDR2, little-endian
+    RTPS_DELIMITED_CDR2_BE = 0x08  # Delimited CDR2, big-endian
+    RTPS_DELIMITED_CDR2_LE = 0x09  # Delimited CDR2, little-endian
+    RTPS_PL_CDR2_BE = 0x0A  # Parameter List CDR2, big-endian
+    RTPS_PL_CDR2_LE = 0x0B  # Parameter List CDR2, little-endian

--- a/cdr/get_encapsulation_kind_info.py
+++ b/cdr/get_encapsulation_kind_info.py
@@ -1,0 +1,77 @@
+"""Utility helpers for :class:`~cdr.encapsulation_kind.EncapsulationKind`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .encapsulation_kind import EncapsulationKind
+
+
+@dataclass(frozen=True)
+class EncapsulationInfo:
+    """Information about the behaviour of an :class:`EncapsulationKind`.
+
+    Attributes correspond to the flags described in the TypeScript
+    implementation.  They are primarily used by the reader and writer to
+    determine how a payload should be serialised or parsed.
+    """
+
+    is_cdr2: bool
+    little_endian: bool
+    uses_delimiter_header: bool
+    uses_member_header: bool
+
+
+def get_encapsulation_kind_info(kind: EncapsulationKind) -> EncapsulationInfo:
+    """Return information about a given ``EncapsulationKind``.
+
+    Parameters
+    ----------
+    kind:
+        The :class:`EncapsulationKind` to inspect.
+
+    Returns
+    -------
+    EncapsulationInfo
+        A data object describing whether the kind is CDR2, little endian
+        and whether it uses delimiter or member headers.
+    """
+
+    is_cdr2 = kind > EncapsulationKind.PL_CDR_LE
+
+    little_endian = kind in {
+        EncapsulationKind.CDR_LE,
+        EncapsulationKind.PL_CDR_LE,
+        EncapsulationKind.CDR2_LE,
+        EncapsulationKind.PL_CDR2_LE,
+        EncapsulationKind.DELIMITED_CDR2_LE,
+        EncapsulationKind.RTPS_CDR2_LE,
+        EncapsulationKind.RTPS_PL_CDR2_LE,
+        EncapsulationKind.RTPS_DELIMITED_CDR2_LE,
+    }
+
+    is_delimited_cdr2 = kind in {
+        EncapsulationKind.DELIMITED_CDR2_BE,
+        EncapsulationKind.DELIMITED_CDR2_LE,
+        EncapsulationKind.RTPS_DELIMITED_CDR2_BE,
+        EncapsulationKind.RTPS_DELIMITED_CDR2_LE,
+    }
+
+    is_pl_cdr2 = kind in {
+        EncapsulationKind.PL_CDR2_BE,
+        EncapsulationKind.PL_CDR2_LE,
+        EncapsulationKind.RTPS_PL_CDR2_BE,
+        EncapsulationKind.RTPS_PL_CDR2_LE,
+    }
+
+    is_pl_cdr1 = kind in {EncapsulationKind.PL_CDR_BE, EncapsulationKind.PL_CDR_LE}
+
+    uses_delimiter_header = is_delimited_cdr2 or is_pl_cdr2
+    uses_member_header = is_pl_cdr2 or is_pl_cdr1
+
+    return EncapsulationInfo(
+        is_cdr2=is_cdr2,
+        little_endian=little_endian,
+        uses_delimiter_header=uses_delimiter_header,
+        uses_member_header=uses_member_header,
+    )

--- a/cdr/is_big_endian.py
+++ b/cdr/is_big_endian.py
@@ -1,0 +1,16 @@
+"""Helpers for determining system endianness."""
+
+from __future__ import annotations
+
+import sys
+
+
+def is_big_endian() -> bool:
+    """Return ``True`` if the current system uses big-endian byte order.
+
+    The TypeScript implementation inspects an ``ArrayBuffer`` to determine
+    endianness.  In Python we can rely on :mod:`sys` which exposes the
+    interpreter's byte order via :data:`sys.byteorder`.
+    """
+
+    return sys.byteorder == "big"

--- a/cdr/length_codes.py
+++ b/cdr/length_codes.py
@@ -1,0 +1,56 @@
+"""Helpers for working with XCDR length codes."""
+
+from __future__ import annotations
+
+from typing import Dict, Literal
+
+LengthCode = Literal[0, 1, 2, 3, 4, 5, 6, 7]
+
+
+class LengthCodeError(ValueError):
+    """Raised when an object size cannot be represented by a length code."""
+
+
+_DEF_SIZES: Dict[int, LengthCode] = {1: 0, 2: 1, 4: 2, 8: 3}
+
+
+def get_length_code_for_object_size(object_size: int) -> LengthCode:
+    """Return the default length code for ``object_size``.
+
+    Parameters
+    ----------
+    object_size:
+        Size in bytes of the value to encode.
+
+    Returns
+    -------
+    LengthCode
+        The length code corresponding to ``object_size``.
+
+    Raises
+    ------
+    LengthCodeError
+        If ``object_size`` is larger than ``0xffffffff`` without an explicit
+        length code.  This mirrors the behaviour of the TypeScript
+        implementation.
+    """
+
+    if object_size in _DEF_SIZES:
+        return _DEF_SIZES[object_size]
+
+    if object_size > 0xFFFFFFFF:
+        raise LengthCodeError(
+            "Object size %d for EMHEADER too large without specifying length code. Max size is %d"
+            % (object_size, 0xFFFFFFFF)
+        )
+
+    # For any other size up to the maximum, a length code of 4 is used.
+    return 4
+
+
+length_code_to_object_sizes: Dict[LengthCode, int] = {
+    0: 1,
+    1: 2,
+    2: 4,
+    3: 8,
+}

--- a/cdr/reader.py
+++ b/cdr/reader.py
@@ -1,0 +1,16 @@
+"""Placeholder for the :class:`CdrReader` implementation.
+
+The original TypeScript project exposes a ``CdrReader`` class capable of
+parsing CDR encoded byte streams.  A full port of that functionality is
+outside the scope of this exercise; however, providing a minimal stub
+allows other modules to import :class:`CdrReader` without failing.
+"""
+
+from __future__ import annotations
+
+
+class CdrReader:
+    """Stub implementation that raises ``NotImplementedError`` on use."""
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple stub
+        raise NotImplementedError("CdrReader is not yet implemented")

--- a/cdr/reserved_pids.py
+++ b/cdr/reserved_pids.py
@@ -1,0 +1,6 @@
+"""Constants for reserved parameter IDs used in XCDR."""
+
+from __future__ import annotations
+
+EXTENDED_PID = 0x3F01
+SENTINEL_PID = 0x3F02

--- a/cdr/size_calculator.py
+++ b/cdr/size_calculator.py
@@ -1,0 +1,10 @@
+"""Placeholder for the :class:`CdrSizeCalculator` implementation."""
+
+from __future__ import annotations
+
+
+class CdrSizeCalculator:
+    """Stub implementation that raises ``NotImplementedError`` on use."""
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple stub
+        raise NotImplementedError("CdrSizeCalculator is not yet implemented")

--- a/cdr/writer.py
+++ b/cdr/writer.py
@@ -1,0 +1,14 @@
+"""Placeholder for the :class:`CdrWriter` implementation.
+
+A full featured writer is not required for the initial port but the class
+is defined so that importing it from the package succeeds.
+"""
+
+from __future__ import annotations
+
+
+class CdrWriter:
+    """Stub implementation that raises ``NotImplementedError`` on use."""
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple stub
+        raise NotImplementedError("CdrWriter is not yet implemented")


### PR DESCRIPTION
## Summary
- port `EncapsulationKind` enum and helper utilities to Python
- expose length code helpers, reserved PIDs and system endianness check
- add stubs for `CdrReader`, `CdrWriter` and `CdrSizeCalculator`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689125e38b7c8330ae2bd0232d56f291