### PR TITLE
Add CdrSizeCalculator implementation and tests

### DIFF
--- a/cdr/size_calculator.py
+++ b/cdr/size_calculator.py
@@ -1,10 +1,91 @@
-"""Placeholder for the :class:`CdrSizeCalculator` implementation."""
+"""Utility for computing CDR encoded message sizes.
+
+This module provides a Python translation of the :code:`CdrSizeCalculator`
+class from the original TypeScript implementation.  The calculator tracks an
+internal offset which represents the number of bytes that would be written
+when serialising values in CDR (Common Data Representation) format.  Each
+method returns the new offset after accounting for padding and the size of the
+written value.
+"""
 
 from __future__ import annotations
 
 
 class CdrSizeCalculator:
-    """Stub implementation that raises ``NotImplementedError`` on use."""
+    """Compute the number of bytes required for CDR serialisation."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple stub
-        raise NotImplementedError("CdrSizeCalculator is not yet implemented")
+    # Two bytes for Representation Id and two bytes for Options
+    def __init__(self) -> None:
+        self._offset = 4
+
+    @property
+    def size(self) -> int:
+        """Return the current offset in bytes."""
+
+        return self._offset
+
+    # Basic integer and floating point types ---------------------------------
+    def int8(self) -> int:
+        return self._increment_and_return(1)
+
+    def uint8(self) -> int:
+        return self._increment_and_return(1)
+
+    def int16(self) -> int:
+        return self._increment_and_return(2)
+
+    def uint16(self) -> int:
+        return self._increment_and_return(2)
+
+    def int32(self) -> int:
+        return self._increment_and_return(4)
+
+    def uint32(self) -> int:
+        return self._increment_and_return(4)
+
+    def int64(self) -> int:
+        return self._increment_and_return(8)
+
+    def uint64(self) -> int:
+        return self._increment_and_return(8)
+
+    def float32(self) -> int:
+        return self._increment_and_return(4)
+
+    def float64(self) -> int:
+        return self._increment_and_return(8)
+
+    # Complex types -----------------------------------------------------------
+    def string(self, length: int) -> int:
+        """Account for a UTF-8 string of ``length`` characters.
+
+        The string is prefixed by a 32-bit unsigned length field and suffixed
+        by a null terminator.  The length parameter should reflect the number
+        of bytes in the string *without* the terminator.
+        """
+
+        self.uint32()  # Encoded string length
+        self._offset += length + 1  # Include null terminator
+        return self._offset
+
+    def sequence_length(self) -> int:
+        """Account for the length field of a sequence."""
+
+        return self.uint32()
+
+    # Private helpers --------------------------------------------------------
+    def _increment_and_return(self, byte_count: int) -> int:
+        """Increment the offset by ``byte_count`` and any required padding.
+
+        The CDR encoding requires that primitive types be aligned to their
+        natural boundaries relative to the start of the CDR stream.  The stream
+        begins with a four byte header, so alignment is performed on
+        ``self._offset - 4``.
+        """
+
+        alignment = (self._offset - 4) % byte_count
+        if alignment > 0:
+            self._offset += byte_count - alignment
+        self._offset += byte_count
+        return self._offset
+

--- a/tests/test_size_calculator.py
+++ b/tests/test_size_calculator.py
@@ -1,0 +1,19 @@
+"""Tests for :mod:`cdr.size_calculator`."""
+
+from __future__ import annotations
+
+from cdr.size_calculator import CdrSizeCalculator
+
+
+def test_string_accounts_for_length_and_terminator() -> None:
+    calc = CdrSizeCalculator()
+    assert calc.size == 4
+    assert calc.string(0) == 9  # 4 bytes length + 1 byte terminator
+    assert calc.size == 9
+
+
+def test_sequence_length_alignment() -> None:
+    calc = CdrSizeCalculator()
+    calc.int8()  # misalign the offset
+    assert calc.sequence_length() == 12  # 3 padding bytes + 4 length bytes
+


### PR DESCRIPTION
## Summary
- port CdrSizeCalculator logic from TypeScript to Python
- test string and sequence length calculations

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68912bb45e48833087e0bf4d617a8024