### PR TITLE
Port encapsulation helpers to Python

### DIFF
--- a/cdr/encapsulation_kind.py
+++ b/cdr/encapsulation_kind.py
@@ -8,16 +8,17 @@ serialized within a CDR stream.
 
 from __future__ import annotations
 
-from enum import IntEnum
+from enum import Enum
 
 
-class EncapsulationKind(IntEnum):
+class EncapsulationKind(Enum):
     """Enumeration of the various CDR encapsulation kinds.
 
-    The integer values match those used by the TypeScript implementation
-    and the DDS-XTypes specification.  They are intentionally defined as
-    ``IntEnum`` so that the values can be used directly in binary
-    operations or compared against integers.
+    The member values match those used by the TypeScript implementation
+    and the DDS-XTypes specification.  ``Enum`` is used instead of
+    :class:`~enum.IntEnum` to provide a closer analogue to TypeScript's
+    ``enum`` semantics; code that requires the numerical value should use
+    the :attr:`value` attribute of each member.
     """
 
     # Plain CDR encodings

--- a/cdr/get_encapsulation_kind_info.py
+++ b/cdr/get_encapsulation_kind_info.py
@@ -37,7 +37,9 @@ def get_encapsulation_kind_info(kind: EncapsulationKind) -> EncapsulationInfo:
         and whether it uses delimiter or member headers.
     """
 
-    is_cdr2 = kind > EncapsulationKind.PL_CDR_LE
+    # ``Enum`` members do not support ordering comparisons directly, so we
+    # compare using their underlying integer values.
+    is_cdr2 = kind.value > EncapsulationKind.PL_CDR_LE.value
 
     little_endian = kind in {
         EncapsulationKind.CDR_LE,


### PR DESCRIPTION
## Summary
- implement EncapsulationKind as a standard Enum
- update get_encapsulation_kind_info to compare enum values directly

## Testing
- `isort --check-only -v cdr/encapsulation_kind.py cdr/get_encapsulation_kind_info.py`
- `black --check cdr/encapsulation_kind.py cdr/get_encapsulation_kind_info.py`
- `flake8 -v cdr/encapsulation_kind.py cdr/get_encapsulation_kind_info.py`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68912baa65d08330a43922973b9f9bea