### PR TITLE
Add pre-commit for Python and development guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/README_PYTHON.md
+++ b/README_PYTHON.md
@@ -1,0 +1,37 @@
+# Python Development
+
+This repository contains a Python implementation of the Common Data Representation (CDR) library. This guide explains how to set up a development environment, run linters with pre-commit, and execute the test suite.
+
+## Environment Setup
+
+1. Ensure Python 3.10 or newer is installed.
+2. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Install the package with development dependencies:
+   ```bash
+   pip install -e .[dev]
+   ```
+
+## pre-commit
+
+This project uses [pre-commit](https://pre-commit.com/) to run formatting and linting tools.
+
+- Install the Git hook scripts:
+  ```bash
+  pre-commit install
+  ```
+- Run all checks:
+  ```bash
+  pre-commit run --all-files
+  ```
+
+## Testing
+
+Run the unit tests with [pytest](https://pytest.org/):
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest",
-  "black",
-  "isort",
-  "flake8",
+  "pre-commit",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- configure pre-commit with Black, isort, and Flake8 for Python sources
- rely on pre-commit for lint tool installation in pyproject
- document Python environment setup, pre-commit usage, and testing

## Testing
- `python -m pre_commit run --files $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68919a91b4248330b55bc0510e75bc71