### PR TITLE
test: validate offsets for all data type sequences

### DIFF
--- a/tests/test_size_calculator.py
+++ b/tests/test_size_calculator.py
@@ -42,3 +42,66 @@ def test_sequence_length_alignment() -> None:
     calc = CdrSizeCalculator()
     calc.int8()  # misalign the offset
     assert calc.sequence_length() == 12  # 3 padding bytes + 4 length bytes
+
+
+def test_all_data_types_without_padding() -> None:
+    """Offsets match Node.js implementation when no padding is required."""
+    calc = CdrSizeCalculator()
+    offset = 4  # initial encapsulation header
+    assert calc.size == offset
+
+    offset += 8
+    assert calc.int64() == offset
+
+    offset += 8
+    assert calc.uint64() == offset
+
+    offset += 8
+    assert calc.float64() == offset
+
+    offset += 4
+    assert calc.int32() == offset
+
+    offset += 4
+    assert calc.uint32() == offset
+
+    offset += 4
+    assert calc.float32() == offset
+
+    offset += 4
+    assert calc.sequence_length() == offset
+
+    offset += 2
+    assert calc.int16() == offset
+
+    offset += 2
+    assert calc.uint16() == offset
+
+    offset += 1
+    assert calc.int8() == offset
+
+    offset += 1
+    assert calc.uint8() == offset
+
+    offset += 2
+    assert calc.uint16() == offset
+
+    offset += 4 + 3 + 1  # length prefix, string data, null terminator
+    assert calc.string(len("abc")) == offset
+
+
+def test_all_data_types_with_padding() -> None:
+    """Offsets match Node.js implementation when padding is required."""
+    calc = CdrSizeCalculator()
+
+    assert calc.size == 4
+    assert calc.int8() == 5
+    assert calc.int64() == 20
+    assert calc.uint16() == 22
+    assert calc.uint32() == 28
+    assert calc.string(0) == 33
+    assert calc.int16() == 36
+    assert calc.uint8() == 37
+    assert calc.float32() == 44
+    assert calc.uint8() == 45
+    assert calc.float64() == 60


### PR DESCRIPTION
## Summary
- add tests for all data types without padding
- add tests for all data types with padding, matching Node.js expectations

## Testing
- `pre-commit run --files tests/test_size_calculator.py`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891a63d48d48330a8cbdade5729e0c2