### PR TITLE
Add CdrWriter round-trip and alignment tests

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3,7 +3,23 @@ from __future__ import annotations
 import pytest
 
 from cdr.encapsulation_kind import EncapsulationKind
+from cdr.reader import CdrReader
 from cdr.writer import CdrWriter
+
+CDR2_KINDS = {
+    EncapsulationKind.CDR2_BE,
+    EncapsulationKind.CDR2_LE,
+    EncapsulationKind.PL_CDR2_BE,
+    EncapsulationKind.PL_CDR2_LE,
+    EncapsulationKind.DELIMITED_CDR2_BE,
+    EncapsulationKind.DELIMITED_CDR2_LE,
+    EncapsulationKind.RTPS_CDR2_BE,
+    EncapsulationKind.RTPS_CDR2_LE,
+    EncapsulationKind.RTPS_PL_CDR2_BE,
+    EncapsulationKind.RTPS_PL_CDR2_LE,
+    EncapsulationKind.RTPS_DELIMITED_CDR2_BE,
+    EncapsulationKind.RTPS_DELIMITED_CDR2_LE,
+}
 
 TF2_MSG_TFMESSAGE = (
     "0001000001000000cce0d158f08cf9060a000000626173655f6c696e6b0000000600000072616461"
@@ -52,3 +68,112 @@ def test_serializes_example_message_without_preallocation() -> None:
     write_example_message(writer)
     assert writer.size == 100
     assert writer.data.hex() == TF2_MSG_TFMESSAGE
+
+
+@pytest.mark.parametrize("kind", list(EncapsulationKind))
+def test_round_trips_all_primitive_types(kind: EncapsulationKind) -> None:
+    writer = CdrWriter(kind=kind)
+    writer.int8(-1)
+    writer.uint8(2)
+    writer.int16(-300)
+    writer.uint16(400)
+    writer.int32(-500_000)
+    writer.uint32(600_000)
+    writer.int64(-7_000_000_001)
+    writer.uint64(8_000_000_003)
+    writer.uint16BE(0x1234)
+    writer.uint32BE(0x12345678)
+    writer.uint64BE(0x123456789ABCDEF0)
+    writer.float32(-9.14)
+    writer.float64(1.7976931348623158e100)
+    writer.string("abc")
+    writer.sequenceLength(42)
+    data = writer.data
+    assert len(data) == (76 if kind in CDR2_KINDS else 80)
+
+    reader = CdrReader(data)
+    assert reader.int8() == -1
+    assert reader.uint8() == 2
+    assert reader.int16() == -300
+    assert reader.uint16() == 400
+    assert reader.int32() == -500_000
+    assert reader.uint32() == 600_000
+    assert reader.int64() == -7_000_000_001
+    assert reader.uint64() == 8_000_000_003
+    assert reader.uint16_be() == 0x1234
+    assert reader.uint32_be() == 0x12345678
+    assert reader.uint64_be() == 0x123456789ABCDEF0
+    assert reader.float32() == pytest.approx(-9.14)
+    assert reader.float64() == pytest.approx(1.7976931348623158e100)
+    assert reader.string() == "abc"
+    assert reader.sequence_length() == 42
+
+
+@pytest.mark.parametrize("kind", list(EncapsulationKind))
+def test_round_trips_all_array_types(kind: EncapsulationKind) -> None:
+    writer = CdrWriter(kind=kind)
+    writer.int8Array([-128, 127, 3], True)
+    writer.uint8Array([0, 255, 3], True)
+    writer.int16Array([-32768, 32767, -3], True)
+    writer.uint16Array([0, 65535, 3], True)
+    writer.int32Array([-2147483648, 2147483647, 3], True)
+    writer.uint32Array([0, 4294967295, 3], True)
+    writer.int64Array([-9223372036854775808, 9223372036854775807, 3], True)
+    writer.uint64Array([0, 18446744073709551615, 3], True)
+
+    reader = CdrReader(writer.data)
+    assert reader.int8_array() == [-128, 127, 3]
+    assert reader.uint8_array() == [0, 255, 3]
+    assert reader.int16_array() == [-32768, 32767, -3]
+    assert reader.uint16_array() == [0, 65535, 3]
+    assert reader.int32_array() == [-2147483648, 2147483647, 3]
+    assert reader.uint32_array() == [0, 4294967295, 3]
+    assert reader.int64_array() == [-9223372036854775808, 9223372036854775807, 3]
+    assert reader.uint64_array() == [0, 18446744073709551615, 3]
+
+
+def test_writes_parameter_list_and_sentinel_header() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_LE)
+    writer.uint8(0x42)
+    writer.sentinelHeader()
+    assert writer.data.hex() == "0003000042000000023f0000"
+
+
+def test_aligns_cdr1() -> None:
+    writer = CdrWriter()
+    writer.align(0)
+    assert writer.data.hex() == "00010000"
+    writer.align(8)
+    assert writer.data.hex() == "00010000"
+    writer.uint8(1)
+    writer.align(8)
+    writer.uint32(2)
+    writer.align(4)
+    assert writer.data.hex() == "00010000010000000000000002000000"
+
+
+def test_aligns_cdr2() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.RTPS_PL_CDR2_LE)
+    writer.align(0)
+    assert writer.data.hex() == "000b0000"
+    writer.align(4)
+    assert writer.data.hex() == "000b0000"
+    writer.uint8(1)
+    writer.align(4)
+    writer.uint32(2)
+    writer.align(4)
+    assert writer.data.hex() == "000b00000100000002000000"
+
+
+def test_aligns_8byte_values_in_pl_cdr_without_emheader() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_LE)
+    writer.uint32(1)
+    writer.uint64(0x0F)
+    assert writer.data.hex() == "0003000001000000000000000f00000000000000"
+
+
+def test_emheader_resets_origin_for_alignment() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_LE)
+    writer.emHeader(True, 5, 8)
+    writer.uint64(0x0F)
+    assert writer.data.hex() == "00030000054008000f00000000000000"


### PR DESCRIPTION
## Summary
- expand test coverage for CdrWriter primitives and arrays across all encapsulation kinds
- verify parameter list sentinel headers and alignment behaviors in CDR1/CDR2

## Testing
- `pre-commit run --files tests/test_writer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a638dc188330aeee6592aa85fdf7