### PR TITLE
Use memoryview for zero-copy array reads

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -122,14 +122,14 @@ def test_round_trips_all_array_types(kind: EncapsulationKind) -> None:
     writer.uint64Array([0, 18446744073709551615, 3], True)
 
     reader = CdrReader(writer.data)
-    assert reader.int8_array() == [-128, 127, 3]
-    assert reader.uint8_array() == [0, 255, 3]
-    assert reader.int16_array() == [-32768, 32767, -3]
-    assert reader.uint16_array() == [0, 65535, 3]
-    assert reader.int32_array() == [-2147483648, 2147483647, 3]
-    assert reader.uint32_array() == [0, 4294967295, 3]
-    assert reader.int64_array() == [-9223372036854775808, 9223372036854775807, 3]
-    assert reader.uint64_array() == [0, 18446744073709551615, 3]
+    assert list(reader.int8_array()) == [-128, 127, 3]
+    assert list(reader.uint8_array()) == [0, 255, 3]
+    assert list(reader.int16_array()) == [-32768, 32767, -3]
+    assert list(reader.uint16_array()) == [0, 65535, 3]
+    assert list(reader.int32_array()) == [-2147483648, 2147483647, 3]
+    assert list(reader.uint32_array()) == [0, 4294967295, 3]
+    assert list(reader.int64_array()) == [-9223372036854775808, 9223372036854775807, 3]
+    assert list(reader.uint64_array()) == [0, 18446744073709551615, 3]
 
 
 def test_writes_parameter_list_and_sentinel_header() -> None:


### PR DESCRIPTION
## Summary
- return zero-copy memoryviews from numeric array readers when alignment and endianness permit
- keep list-based fallback when zero-copy is unsafe
- extend tests for memoryview behaviour and endian mismatch

## Testing
- `pre-commit run --files cdr/reader.py tests/test_reader.py tests/test_writer.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891aa8beb708330a9fb3538ddae5e8a