### PR TITLE
Return zero-copy views for aligned arrays

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -167,7 +167,10 @@ def test_array_bulk_and_fallback_paths(
     getattr(writer, method)(data, True)
     reader = CdrReader(writer.data)
     read_method = method.replace("Array", "_array")
-    assert getattr(reader, read_method)() == values
+    result = getattr(reader, read_method)()
+    if isinstance(result, memoryview):
+        result = list(result)
+    assert result == values
 
 
 def test_writes_parameter_list_and_sentinel_header() -> None:


### PR DESCRIPTION
## Summary
- Return memoryviews for aligned numeric arrays to avoid copies
- Normalize writer tests for memoryview-based array reads
- Add parameterized tests proving numeric array readers share buffer without copying

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891adc42fd48330b8b574ae50fc2f19