### PR TITLE
Add typing support and satisfy mypy

### DIFF
--- a/cdr/writer.py
+++ b/cdr/writer.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import struct
 from array import array as Array
-from typing import Sequence
+from collections.abc import Buffer
+from typing import Sequence, cast
 
 from .encapsulation_kind import EncapsulationKind
 from .get_encapsulation_kind_info import get_encapsulation_kind_info
@@ -538,7 +539,7 @@ class CdrWriter:
         """
 
         try:
-            mv = memoryview(value)
+            mv = memoryview(cast(Buffer, value))
         except TypeError:
             return False
 

--- a/cdr/writer.py
+++ b/cdr/writer.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 
 import struct
 from array import array as Array
-from collections.abc import Buffer
 from typing import Sequence, cast
+
+try:  # Python 3.12+
+    from collections.abc import Buffer
+except ImportError:  # Python <3.12
+    from typing_extensions import Buffer
 
 from .encapsulation_kind import EncapsulationKind
 from .get_encapsulation_kind_info import get_encapsulation_kind_info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Python package for the cdr project"
 requires-python = ">=3.10"
 dependencies = [
-  "typing",
+  "typing-extensions",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- refine member header parsing and array helpers with explicit casts and typed memoryviews
- cast buffer-like inputs in writer for safe contiguous writes
- simplify array reader interfaces by returning generic sequences instead of explicit list/memoryview unions

## Testing
- `pytest`
- `mypy cdr`


------
https://chatgpt.com/codex/tasks/task_e_6897e46cfc508330a56a6802d96eaeff